### PR TITLE
Fix woff2 user agent string so that only the defined language subsets are provided by google's API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ if (formats.length == 0) {
 }
 
 var userAgentMap = {
-  woff2: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36",
+  woff2: "Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/40.0",
   woff: "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
   eot:  "Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)",
   svg:  "Mozilla/4.0 (iPad; CPU OS 4_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/4.1 Mobile/9A405 Safari/7534.48.3",


### PR DESCRIPTION
The current user agent string for woff2 google webfont downloads all subsets, no matter if you restrict them. Google does this by design if they detect that the user agent string in the request is able to handle all possible subsets. Currently, *at least* the user agent Chrome/51.0.2704.106 causes this to happen. I managed to fix this on my setup by changing the agent to Firefox 40.