### PR TITLE
separated library and CLI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,41 @@
+{
+    "env": { "node": true },
+    "globals": { "Promise": true },
+    "parserOptions": {
+        "ecmaVersion": 6
+    },
+    "ecmaFeatures": {
+        "forOf": true,
+        
+        "arrowFunctions": false,
+        "binaryLiterals": false,
+        "blockBindings": false,
+        "classes": false,
+        "defaultParams": false,
+        "destructuring": false,
+        "generators": false,
+        "modules": false,
+        "objectLiteralComputedProperties": false,
+        "objectLiteralDuplicateProperties": false,
+        "objectLiteralShorthandMethods": false,
+        "objectLiteralShorthandProperties": false,
+        "octalLiterals": false,
+        "regexUFlag": false,
+        "regexYFlag": false,
+        "restParams": false,
+        "spread": false,
+        "superInFunctions": false,
+        "templateStrings": false,
+        "unicodeCodePointEscapes": false
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent":          [2, 2],
+        "linebreak-style": [2, "unix"],
+        "quotes":          [2, "double"],
+        "semi":            [2, "always"],
+        "eqeqeq":          [2, "always", { "null": "ignore" }],
+        "func-style":      [2, "declaration"],
+        "no-console":      [0]
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - 0.12

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ goog-webfont-dl is a [Google WebFont](https://www.google.com/fonts) utility to d
 ## Usage
 
 ```
-Usage: goog-webfont-dl [options]
+Usage: goog-webfont-dl [options] <fontname>
 
   Options:
 
@@ -19,10 +19,10 @@ Usage: goog-webfont-dl [options]
     -W, --woff2                    Download WOFF2 format
     -s, --svg                      Download SVG format
     -a, --all                      Download all formats
-    -f, --font [name]              Name of font
-    -d, --destination [directory]  Save font in directory
-    -o, --out [name]               CSS output file [use - for stdout]
-    -p, --prefix [prefix]          Prefix to use in CSS output
+    -f, --font [fontname]          Name of font
+    -d, --destination [directory]  Save font in directory [default: <fontname>/]
+    -o, --out [csspath]            CSS output file [use - for stdout. default: <fontname>.css]
+    -p, --prefix [prefix]          Prefix to use in CSS output [default: ../fonts/<fontname>/]
     -u, --subset [string]          Subset string [e.g. latin,cyrillic]
     -y, --styles [string]          Style string [e.g. 300,400,300italic,400italic]
     -P, --proxy [string]           Proxy url [e.g. http://www.myproxy.com/]
@@ -33,6 +33,33 @@ Install as global command line utility
 ```shell
 npm install -g goog-webfont-dl
 ```
+
+## Library
+
+This package is compatible with Node 0.12 and above.
+
+```js
+const downloader = require('goog-webfont-dl')
+// or
+import downloader from 'goog-webfont-dl'
+
+const css = downloader('Some Font name')
+// or
+const css = downloader({
+  // required:
+  font: 'Some Font name',
+  // defaults:
+  formats:     downloader.formats, // Font formats. 
+  destination: font,               // Save font here
+  out:         null, // = return   // CSS file. Use '-' for stdout, and nothing to return the CSS code
+  prefix:      `../fonts/${font}`, // Prefix to use in CSS output
+  subset:      null, // = none     // Subset string/array, e.g. 'latin,cyrillic'
+  styles:      downloader.styles,  // Style string/array, e.g. '300,400,300italic,400italic'
+  proxy:       null, // = none     // Proxy url, e.g. 'https://myproxy.com'
+})
+```
+
+Since `Array.prototype.toString` works by joining array elements with commas, `subset` or `styles` can be specified as array as well.
 
 ## Example
 

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+var commander = require("commander");
+
+var downloader = require(".");
+
+commander
+  .version(require("./package.json").version)
+  .usage("[options] <fontname>")
+  .option("-t, --ttf", "Download TTF format")
+  .option("-e, --eot", "Download EOT format")
+  .option("-w, --woff", "Download WOFF format")
+  .option("-W, --woff2", "Download WOFF2 format")
+  .option("-s, --svg", "Download SVG format")
+  .option("-a, --all", "Download all formats")
+  .option("-f, --font [name]", "Name of font")
+  .option("-d, --destination [directory]", "Save font in directory")
+  .option("-o, --out [name]", "CSS output file [use - for stdout]")
+  .option("-p, --prefix [prefix]", "Prefix to use in CSS output")
+  .option("-u, --subset [string]", "Subset string [e.g. latin,cyrillic]")
+  .option("-y, --styles [string]", "Style string [e.g. 300,400,300italic,400italic]")
+  .option("-P, --proxy [string]", "Proxy url [e.g. http://www.myproxy.com/]")
+  .option("-q, --quiet", "Do not print status information")
+
+  .parse(process.argv);
+
+// validate font
+if (!commander.font) {
+  if (commander.args.length === 1) {
+    commander.font = commander.args[0];
+  }
+  else {
+    console.error("You need to give a (single) font name");
+    process.exit(1);
+  }
+}
+delete commander.args;
+
+// validate and prepare formats
+commander.formats = (commander.all)
+  ? downloader.formats
+  : downloader.formats.filter(function(f) { return !!commander[f]; });
+
+if (commander.formats.length === 0) {
+  console.error("please select at least one format (or -a for all formats)");
+  process.exit(1);
+}
+
+for (var f of downloader.formats) {
+  delete commander[f];
+}
+
+// set CSS file
+if (!commander.out) {
+  commander.out = commander.font + ".css";
+}
+
+// transform quiet → verbose. CLI is verbose per default, library is quiet
+commander.verbose = !commander.quiet;
+delete commander.quiet;
+
+downloader(commander);

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.4.1",
   "description": "A utility to download google webfonts to your local machine",
   "bin": {
-    "goog-webfont-dl": "./index.js"
+    "goog-webfont-dl": "./cli.js"
   },
+  "main": "./index.js",
   "dependencies": {
     "request": "~2.53.0",
     "css": "~2.1.0",
@@ -32,5 +33,8 @@
   },
   "engines": {
     "node": ">=0.12"
+  },
+  "devDependencies": {
+    "eslint": "^3.9.1"
   }
 }


### PR DESCRIPTION
the library has the same options as the CLI, only that formats are specified as array, and `--quiet` corresponds to `!options.verbose`

when nothing, `null`, or `'all'` is specified, download all formats, else the ones in the array.

also:

* added eslint config (`for..of` is in node 0.12, therefore the huge `ecmaFeatures` block)
* switched errors from `stdout` (`console.log`) to `stderr` (`console.error`)
* only create a CSS file if at least the first font file could be downloaded (moved `cssOut` to `doDownload`)
* added `--quiet`/`options.verbose`

fixes #10