### PR TITLE
Enforce some more stylistic choices in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,12 +30,14 @@
     },
     "extends": "eslint:recommended",
     "rules": {
-        "indent":          [2, 2],
-        "linebreak-style": [2, "unix"],
-        "quotes":          [2, "double"],
-        "semi":            [2, "always"],
-        "eqeqeq":          [2, "always", { "null": "ignore" }],
-        "func-style":      [2, "declaration"],
-        "no-console":      [0]
+        "indent":             [2, 2],
+        "linebreak-style":    [2, "unix"],
+        "quotes":             [2, "double"],
+        "semi":               [2, "always"],
+        "eqeqeq":             [2, "always", { "null": "ignore" }],
+        "brace-style":        [2, "stroustrup"],
+        "func-style":         [2, "declaration"],
+        "no-console":         [0],
+        "no-trailing-spaces": [2]
     }
 }


### PR DESCRIPTION
to avoid commits like 365f01fece83a58b6f1cfdf3894945c99b0426e1

for 2 the real changes check https://github.com/jrnewell/goog-webfont-dl/pull/12/files?w=1