### PR TITLE
Fix for fonts not being downloaded when local name definition was missing #19

### DIFF
--- a/cssParser.js
+++ b/cssParser.js
@@ -147,7 +147,7 @@ function parseCSS(format, options, results, cssText) {
 
       if (!subObj.defaultLocalName) {
         // some fonts do not have a local name provided - generate it from the font name
-        if (localNames.length == 0) subObj.defaultLocalName = family+" - "+style;
+        if (localNames.length == 0) subObj.defaultLocalName = (family+"-"+style+"-"+weight).replace(/[\s]+/g, "-");
         else subObj.defaultLocalName = localNames[0].replace(/[\s]+/g, "-");
       }
       var defaultLocalName = subObj.defaultLocalName;

--- a/cssParser.js
+++ b/cssParser.js
@@ -136,7 +136,7 @@ function parseCSS(format, options, results, cssText) {
       }
     }
 
-    if (urls.length > 0 && localNames.length > 0 && subset !== null &&
+    if (urls.length > 0 && subset !== null &&
         family !== null && style !== null && weight !== null)
     {
       var subObj = getSubObj(results.cssObj, [subset, family, style, weight]);
@@ -146,6 +146,8 @@ function parseCSS(format, options, results, cssText) {
       subObj.localNames = _.union(subObj.localNames, localNames);
 
       if (!subObj.defaultLocalName) {
+        // some fonts do not have a local name provided - generate it from the font name
+        if (localNames.length == 0) subObj.defaultLocalName = family+" - "+style;
         subObj.defaultLocalName = localNames[0].replace(/[\s]+/g, "-");
       }
       var defaultLocalName = subObj.defaultLocalName;

--- a/cssParser.js
+++ b/cssParser.js
@@ -148,7 +148,7 @@ function parseCSS(format, options, results, cssText) {
       if (!subObj.defaultLocalName) {
         // some fonts do not have a local name provided - generate it from the font name
         if (localNames.length == 0) subObj.defaultLocalName = family+" - "+style;
-        subObj.defaultLocalName = localNames[0].replace(/[\s]+/g, "-");
+        else subObj.defaultLocalName = localNames[0].replace(/[\s]+/g, "-");
       }
       var defaultLocalName = subObj.defaultLocalName;
 


### PR DESCRIPTION
Some fonts, like Orbitron, do not come with a local name definition: https://fonts.googleapis.com/css?family=Orbitron:900, which prevents them from being downloaded.
This PR fixes the problem by generating a default name, generated from font family, style and weight for such fonts.